### PR TITLE
fix: use relative import for ts model

### DIFF
--- a/src/lib/operators/transformation/map-to-dictionary/map-to-dictionary.ts
+++ b/src/lib/operators/transformation/map-to-dictionary/map-to-dictionary.ts
@@ -1,6 +1,6 @@
-import { Dictionary } from '@app/models';
 import { Observable, OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { Dictionary } from '../../../models';
 
 export function mapToDictionary<T>(
   idSelector?: string | ((signal: T) => number | string)

--- a/src/lib/operators/transformation/map-to-list/map-to-list.ts
+++ b/src/lib/operators/transformation/map-to-list/map-to-list.ts
@@ -1,6 +1,6 @@
-import { Dictionary } from '@app/models';
 import { Observable, OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { Dictionary } from '../../../models';
 import { objectKeys } from '../../../utils';
 
 export function mapToList<T>(): OperatorFunction<Dictionary<T>, T[]> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,8 +41,7 @@
 
     "baseUrl": ".",
     "paths": {
-      "@app/operators": ["src/lib/operators/index.ts"],
-      "@app/models": ["src/lib/models/index.ts"]
+      "@app/operators": ["src/lib/operators/index.ts"]
     }
   },
   "include": ["src/**/*.ts"],

--- a/tslint.json
+++ b/tslint.json
@@ -4,7 +4,7 @@
     "interface-name": [true, "never-prefix"],
     // TODO: allow devDependencies only in **/*.spec.ts files:
     // waiting on https://github.com/palantir/tslint/pull/3708
-    "no-implicit-dependencies": [true, "dev", ["@app/operators", "@app/models"]],
+    "no-implicit-dependencies": [true, "dev", ["@app/operators"]],
     "no-submodule-imports": [true, "rxjs"],
     "no-console": [false],
     "no-angle-bracket-type-assertion": false


### PR DESCRIPTION
This error came up in pentacle with v1.5

```
ERROR in node_modules/rxjs-toolkit/build/main/lib/operators/transformation/map-to-dictionary/map-to-dictionary.d.ts(1,28): error TS2307: Cannot find module '@app/models'.
node_modules/rxjs-toolkit/build/main/lib/operators/transformation/map-to-list/map-to-list.d.ts(1,28): error TS2307: Cannot find module '@app/models'.
```

Attempting to use relative paths instead! :'(